### PR TITLE
Provide meaningful string names to Cylinder inputs

### DIFF
--- a/inputFiles/surfaceGeneration/DryFrac_StaticPenny_PrismElem.xml
+++ b/inputFiles/surfaceGeneration/DryFrac_StaticPenny_PrismElem.xml
@@ -42,8 +42,8 @@
   <Geometry>
     <Cylinder
       name="fracPlane"
-      lowerFaceCenter="{ 0.0, 0.0, -0.1 }"
-      upperFaceCenter="{ 0.0, 0.0, 0.1 }"
+      firstFaceCenter="{ 0.0, 0.0, -0.1 }"
+      secondFaceCenter="{ 0.0, 0.0, 0.1 }"
       radius="11"/>
 
     <Box

--- a/inputFiles/surfaceGeneration/DryFrac_StaticPenny_PrismElem.xml
+++ b/inputFiles/surfaceGeneration/DryFrac_StaticPenny_PrismElem.xml
@@ -42,8 +42,8 @@
   <Geometry>
     <Cylinder
       name="fracPlane"
-      point1="{ 0.0, 0.0, -0.1 }"
-      point2="{ 0.0, 0.0, 0.1 }"
+      lowerFaceCenter="{ 0.0, 0.0, -0.1 }"
+      upperFaceCenter="{ 0.0, 0.0, 0.1 }"
       radius="11"/>
 
     <Box

--- a/inputFiles/surfaceGeneration/DryFrac_StaticPenny_PrismElem.xml
+++ b/inputFiles/surfaceGeneration/DryFrac_StaticPenny_PrismElem.xml
@@ -44,7 +44,7 @@
       name="fracPlane"
       firstFaceCenter="{ 0.0, 0.0, -0.1 }"
       secondFaceCenter="{ 0.0, 0.0, 0.1 }"
-      radius="11"/>
+      outerRadius="11"/>
 
     <Box
       name="core"

--- a/src/coreComponents/mesh/simpleGeometricObjects/Cylinder.cpp
+++ b/src/coreComponents/mesh/simpleGeometricObjects/Cylinder.cpp
@@ -43,7 +43,7 @@ Cylinder::Cylinder( const string & name, Group * const parent ):
 
   registerWrapper( viewKeyStruct::radiusString(), &m_radius ).
     setInputFlag( InputFlags::REQUIRED ).
-    setDescription( "Radius of the cylinder, outer radius of the annulus" );
+    setDescription( "Outer radius of the cylinder" );
 
   registerWrapper( viewKeyStruct::innerRadiusString(), &m_innerRadius ).
     setApplyDefaultValue( -1 ).

--- a/src/coreComponents/mesh/simpleGeometricObjects/Cylinder.cpp
+++ b/src/coreComponents/mesh/simpleGeometricObjects/Cylinder.cpp
@@ -35,7 +35,7 @@ Cylinder::Cylinder( const string & name, Group * const parent ):
 {
   registerWrapper( viewKeyStruct::point1String(), &m_point1 ).
     setInputFlag( InputFlags::REQUIRED ).
-    setDescription( "Center point the lower face of the cylinder" );
+    setDescription( "Center point of the lower face of the cylinder" );
 
   registerWrapper( viewKeyStruct::point2String(), &m_point2 ).
     setInputFlag( InputFlags::REQUIRED ).

--- a/src/coreComponents/mesh/simpleGeometricObjects/Cylinder.cpp
+++ b/src/coreComponents/mesh/simpleGeometricObjects/Cylinder.cpp
@@ -35,15 +35,15 @@ Cylinder::Cylinder( const string & name, Group * const parent ):
 {
   registerWrapper( viewKeyStruct::point1String(), &m_point1 ).
     setInputFlag( InputFlags::REQUIRED ).
-    setDescription( "Center point of one (upper or lower) face of the cylinder" );
+    setDescription( "Center point the lower face of the cylinder" );
 
   registerWrapper( viewKeyStruct::point2String(), &m_point2 ).
     setInputFlag( InputFlags::REQUIRED ).
-    setDescription( "Center point of the other face of the cylinder" );
+    setDescription( "Center point of the upper face of the cylinder" );
 
   registerWrapper( viewKeyStruct::radiusString(), &m_radius ).
     setInputFlag( InputFlags::REQUIRED ).
-    setDescription( "Radius of the cylinder" );
+    setDescription( "Radius of the cylinder, outer radius of the annulus" );
 
   registerWrapper( viewKeyStruct::innerRadiusString(), &m_innerRadius ).
     setApplyDefaultValue( -1 ).

--- a/src/coreComponents/mesh/simpleGeometricObjects/Cylinder.cpp
+++ b/src/coreComponents/mesh/simpleGeometricObjects/Cylinder.cpp
@@ -35,11 +35,11 @@ Cylinder::Cylinder( const string & name, Group * const parent ):
 {
   registerWrapper( viewKeyStruct::point1String(), &m_point1 ).
     setInputFlag( InputFlags::REQUIRED ).
-    setDescription( "Center point of the lower face of the cylinder" );
+    setDescription( "Center point of the first face of the cylinder" );
 
   registerWrapper( viewKeyStruct::point2String(), &m_point2 ).
     setInputFlag( InputFlags::REQUIRED ).
-    setDescription( "Center point of the upper face of the cylinder" );
+    setDescription( "Center point of the second face of the cylinder" );
 
   registerWrapper( viewKeyStruct::radiusString(), &m_radius ).
     setInputFlag( InputFlags::REQUIRED ).

--- a/src/coreComponents/mesh/simpleGeometricObjects/Cylinder.hpp
+++ b/src/coreComponents/mesh/simpleGeometricObjects/Cylinder.hpp
@@ -74,7 +74,7 @@ public:
   {
     static constexpr char const * point1String() { return "firstFaceCenter"; }
     static constexpr char const * point2String() { return "secondFaceCenter"; }
-    static constexpr char const * radiusString() { return "radius"; }
+    static constexpr char const * radiusString() { return "outerRadius"; }
     static constexpr char const * innerRadiusString() { return "innerRadius"; }
   };
 
@@ -88,7 +88,7 @@ private:
   /// Center point of the second face of the cylinder
   R1Tensor m_point2;
 
-  /// Radius of the cylinder
+  /// Outer radius of the cylinder
   real64 m_radius = 0.0;
 
   /// Inner radius of the annulus

--- a/src/coreComponents/mesh/simpleGeometricObjects/Cylinder.hpp
+++ b/src/coreComponents/mesh/simpleGeometricObjects/Cylinder.hpp
@@ -72,8 +72,8 @@ public:
 
   struct viewKeyStruct
   {
-    static constexpr char const * point1String() { return "lowerFaceCenter"; }
-    static constexpr char const * point2String() { return "upperFaceCenter"; }
+    static constexpr char const * point1String() { return "firstFaceCenter"; }
+    static constexpr char const * point2String() { return "secondFaceCenter"; }
     static constexpr char const * radiusString() { return "radius"; }
     static constexpr char const * innerRadiusString() { return "innerRadius"; }
   };
@@ -82,13 +82,16 @@ public:
 
 private:
 
-  /// Center point of the lower face of the cylinder
+  /// Center point of the first face of the cylinder
   R1Tensor m_point1;
-  /// Center point of the upper face of the cylinder
+
+  /// Center point of the second face of the cylinder
   R1Tensor m_point2;
+
   /// Radius of the cylinder
   real64 m_radius = 0.0;
-  /// Inner radius of the cylinder
+
+  /// Inner radius of the annulus
   real64 m_innerRadius = 0.0;
 
 };

--- a/src/coreComponents/mesh/simpleGeometricObjects/Cylinder.hpp
+++ b/src/coreComponents/mesh/simpleGeometricObjects/Cylinder.hpp
@@ -72,8 +72,8 @@ public:
 
   struct viewKeyStruct
   {
-    static constexpr char const * point1String() { return "point1"; }
-    static constexpr char const * point2String() { return "point2"; }
+    static constexpr char const * point1String() { return "lowerFaceCenter"; }
+    static constexpr char const * point2String() { return "upperFaceCenter"; }
     static constexpr char const * radiusString() { return "radius"; }
     static constexpr char const * innerRadiusString() { return "innerRadius"; }
   };
@@ -82,9 +82,9 @@ public:
 
 private:
 
-  /// Center point of one (upper or lower) face of the cylinder
+  /// Center point of the lower face of the cylinder
   R1Tensor m_point1;
-  /// Center point of the other face of the cylinder
+  /// Center point of the upper face of the cylinder
   R1Tensor m_point2;
   /// Radius of the cylinder
   real64 m_radius = 0.0;

--- a/src/coreComponents/schema/docs/Cylinder.rst
+++ b/src/coreComponents/schema/docs/Cylinder.rst
@@ -1,13 +1,13 @@
 
 
-=============== ======== ======== =================================================== 
-Name            Type     Default  Description                                         
-=============== ======== ======== =================================================== 
-innerRadius     real64   -1       Inner radius of the annulus                         
-lowerFaceCenter R1Tensor required Center point of the lower face of the cylinder         
-name            string   required A name is required for any non-unique nodes         
-radius          real64   required Radius of the cylinder, outer radius of the annulus 
-upperFaceCenter R1Tensor required Center point of the upper face of the cylinder      
-=============== ======== ======== =================================================== 
+================ ======== ======== =================================================== 
+Name             Type     Default  Description                                         
+================ ======== ======== =================================================== 
+innerRadius      real64   -1       Inner radius of the annulus                         
+firstFaceCenter  R1Tensor required Center point of the first face of the cylinder    
+secondFaceCenter R1Tensor required Center point of the second face of the cylinder         
+name             string   required A name is required for any non-unique nodes         
+radius           real64   required Radius of the cylinder, outer radius of the annulus   
+================ ======== ======== =================================================== 
 
 

--- a/src/coreComponents/schema/docs/Cylinder.rst
+++ b/src/coreComponents/schema/docs/Cylinder.rst
@@ -3,11 +3,11 @@
 ================ ======== ======== =================================================== 
 Name             Type     Default  Description                                         
 ================ ======== ======== =================================================== 
-innerRadius      real64   -1       Inner radius of the annulus                         
+name             string   required A name is required for any non-unique nodes   
 firstFaceCenter  R1Tensor required Center point of the first face of the cylinder    
 secondFaceCenter R1Tensor required Center point of the second face of the cylinder         
-name             string   required A name is required for any non-unique nodes         
-radius           real64   required Radius of the cylinder, outer radius of the annulus   
+outerRadius      real64   required Outer radius of the cylinder   
+innerRadius      real64   -1       Inner radius of the annulus                         
 ================ ======== ======== =================================================== 
 
 

--- a/src/coreComponents/schema/docs/Cylinder.rst
+++ b/src/coreComponents/schema/docs/Cylinder.rst
@@ -4,7 +4,7 @@
 Name            Type     Default  Description                                         
 =============== ======== ======== =================================================== 
 innerRadius     real64   -1       Inner radius of the annulus                         
-lowerFaceCenter R1Tensor required Center point the lower face of the cylinder         
+lowerFaceCenter R1Tensor required Center point of the lower face of the cylinder         
 name            string   required A name is required for any non-unique nodes         
 radius          real64   required Radius of the cylinder, outer radius of the annulus 
 upperFaceCenter R1Tensor required Center point of the upper face of the cylinder      

--- a/src/coreComponents/schema/docs/Cylinder.rst
+++ b/src/coreComponents/schema/docs/Cylinder.rst
@@ -1,13 +1,13 @@
 
 
-=========== ======== ======== ========================================================= 
-Name        Type     Default  Description                                               
-=========== ======== ======== ========================================================= 
-innerRadius real64   -1       Inner radius of the annulus                               
-name        string   required A name is required for any non-unique nodes               
-point1      R1Tensor required Center point of one (upper or lower) face of the cylinder 
-point2      R1Tensor required Center point of the other face of the cylinder            
-radius      real64   required Radius of the cylinder                                    
-=========== ======== ======== ========================================================= 
+=============== ======== ======== =================================================== 
+Name            Type     Default  Description                                         
+=============== ======== ======== =================================================== 
+innerRadius     real64   -1       Inner radius of the annulus                         
+lowerFaceCenter R1Tensor required Center point the lower face of the cylinder         
+name            string   required A name is required for any non-unique nodes         
+radius          real64   required Radius of the cylinder, outer radius of the annulus 
+upperFaceCenter R1Tensor required Center point of the upper face of the cylinder      
+=============== ======== ======== =================================================== 
 
 

--- a/src/coreComponents/schema/schema.xsd
+++ b/src/coreComponents/schema/schema.xsd
@@ -1245,14 +1245,14 @@ stress - traction is applied to the faces as specified by the inner product of i
 		<xsd:attribute name="name" type="string" use="required" />
 	</xsd:complexType>
 	<xsd:complexType name="CylinderType">
-		<!--innerRadius => Inner radius of the annulus-->
-		<xsd:attribute name="innerRadius" type="real64" default="-1" />
-		<!--lowerFaceCenter => Center point of the lower face of the cylinder-->
-		<xsd:attribute name="lowerFaceCenter" type="R1Tensor" use="required" />
+		<!--firstFaceCenter => Center point of the first face of the cylinder-->
+		<xsd:attribute name="firstFaceCenter" type="R1Tensor" use="required" />
+        <!--secondFaceCenter => Center point of the second face of the cylinder-->
+		<xsd:attribute name="secondFaceCenter" type="R1Tensor" use="required" />
 		<!--radius => Radius of the cylinder, outer radius of the annulus-->
 		<xsd:attribute name="radius" type="real64" use="required" />
-		<!--upperFaceCenter => Center point of the upper face of the cylinder-->
-		<xsd:attribute name="upperFaceCenter" type="R1Tensor" use="required" />
+        <!--innerRadius => Inner radius of the annulus-->
+		<xsd:attribute name="innerRadius" type="real64" default="-1" />
 		<!--name => A name is required for any non-unique nodes-->
 		<xsd:attribute name="name" type="string" use="required" />
 	</xsd:complexType>

--- a/src/coreComponents/schema/schema.xsd
+++ b/src/coreComponents/schema/schema.xsd
@@ -514,6 +514,10 @@
 					<xsd:selector xpath="CompressibleSolidConstantPermeability" />
 					<xsd:field xpath="@name" />
 				</xsd:unique>
+				<xsd:unique name="ConstitutiveCompressibleSolidExponentialDecayPermeabilityUniqueName">
+					<xsd:selector xpath="CompressibleSolidExponentialDecayPermeability" />
+					<xsd:field xpath="@name" />
+				</xsd:unique>
 				<xsd:unique name="ConstitutiveCompressibleSolidParallelPlatesPermeabilityUniqueName">
 					<xsd:selector xpath="CompressibleSolidParallelPlatesPermeability" />
 					<xsd:field xpath="@name" />
@@ -572,6 +576,10 @@
 				</xsd:unique>
 				<xsd:unique name="ConstitutiveElasticTransverseIsotropicUniqueName">
 					<xsd:selector xpath="ElasticTransverseIsotropic" />
+					<xsd:field xpath="@name" />
+				</xsd:unique>
+				<xsd:unique name="ConstitutiveExponentialDecayPermeabilityUniqueName">
+					<xsd:selector xpath="ExponentialDecayPermeability" />
 					<xsd:field xpath="@name" />
 				</xsd:unique>
 				<xsd:unique name="ConstitutiveExtendedDruckerPragerUniqueName">
@@ -1239,12 +1247,12 @@ stress - traction is applied to the faces as specified by the inner product of i
 	<xsd:complexType name="CylinderType">
 		<!--innerRadius => Inner radius of the annulus-->
 		<xsd:attribute name="innerRadius" type="real64" default="-1" />
-		<!--point1 => Center point of one (upper or lower) face of the cylinder-->
-		<xsd:attribute name="point1" type="R1Tensor" use="required" />
-		<!--point2 => Center point of the other face of the cylinder-->
-		<xsd:attribute name="point2" type="R1Tensor" use="required" />
-		<!--radius => Radius of the cylinder-->
+		<!--lowerFaceCenter => Center point the lower face of the cylinder-->
+		<xsd:attribute name="lowerFaceCenter" type="R1Tensor" use="required" />
+		<!--radius => Radius of the cylinder, outer radius of the annulus-->
 		<xsd:attribute name="radius" type="real64" use="required" />
+		<!--upperFaceCenter => Center point of the upper face of the cylinder-->
+		<xsd:attribute name="upperFaceCenter" type="R1Tensor" use="required" />
 		<!--name => A name is required for any non-unique nodes-->
 		<xsd:attribute name="name" type="string" use="required" />
 	</xsd:complexType>
@@ -3222,7 +3230,7 @@ The expected format is "{ waterMax, oilMax }", in that order-->
 		<!--name => A name is required for any non-unique nodes-->
 		<xsd:attribute name="name" type="string" use="required" />
 	</xsd:complexType>
-        <xsd:complexType name="CompressibleSolidExponentialDecayPermeabilityType">
+	<xsd:complexType name="CompressibleSolidExponentialDecayPermeabilityType">
 		<!--permeabilityModelName => Name of the permeability model.-->
 		<xsd:attribute name="permeabilityModelName" type="string" use="required" />
 		<!--porosityModelName => Name of the porosity model.-->
@@ -3575,9 +3583,9 @@ For instance, if "oil" is before "gas" in "phaseNames", the table order should b
 		<xsd:attribute name="name" type="string" use="required" />
 	</xsd:complexType>
 	<xsd:complexType name="ExponentialDecayPermeabilityType">
-		<!--empiricalConstant => An empirical constant.-->
+		<!--empiricalConstant => an empirical constant.-->
 		<xsd:attribute name="empiricalConstant" type="real64" use="required" />
-                <!--initialPermeability => Initial permeability of the fracture.-->
+		<!--initialPermeability =>  initial permeability of the fracture.-->
 		<xsd:attribute name="initialPermeability" type="R1Tensor" use="required" />
 		<!--name => A name is required for any non-unique nodes-->
 		<xsd:attribute name="name" type="string" use="required" />

--- a/src/coreComponents/schema/schema.xsd
+++ b/src/coreComponents/schema/schema.xsd
@@ -1249,8 +1249,8 @@ stress - traction is applied to the faces as specified by the inner product of i
 		<xsd:attribute name="firstFaceCenter" type="R1Tensor" use="required" />
         <!--secondFaceCenter => Center point of the second face of the cylinder-->
 		<xsd:attribute name="secondFaceCenter" type="R1Tensor" use="required" />
-		<!--radius => Radius of the cylinder, outer radius of the annulus-->
-		<xsd:attribute name="radius" type="real64" use="required" />
+		<!--outerRadius => Outer radius of the cylinder-->
+		<xsd:attribute name="outerRadius" type="real64" use="required" />
         <!--innerRadius => Inner radius of the annulus-->
 		<xsd:attribute name="innerRadius" type="real64" default="-1" />
 		<!--name => A name is required for any non-unique nodes-->

--- a/src/coreComponents/schema/schema.xsd
+++ b/src/coreComponents/schema/schema.xsd
@@ -1247,7 +1247,7 @@ stress - traction is applied to the faces as specified by the inner product of i
 	<xsd:complexType name="CylinderType">
 		<!--innerRadius => Inner radius of the annulus-->
 		<xsd:attribute name="innerRadius" type="real64" default="-1" />
-		<!--lowerFaceCenter => Center point the lower face of the cylinder-->
+		<!--lowerFaceCenter => Center point of the lower face of the cylinder-->
 		<xsd:attribute name="lowerFaceCenter" type="R1Tensor" use="required" />
 		<!--radius => Radius of the cylinder, outer radius of the annulus-->
 		<xsd:attribute name="radius" type="real64" use="required" />


### PR DESCRIPTION
Cylinder geometry will be extensively considered in the near future for wellbore problems. This tiny PR provides meaningfull strings to Cylinder inputs as follow:

`point1` is changed to `lowerFaceCenter`
`point2` is changed to `upperFaceCenter`

This is only changed on the user side for instant. This will help the users to better understand the input data in xml files.
Rebaseline is not needed for this PR.

Rebaseline done in https://github.com/GEOSX/integratedTests/pull/312