### PR TITLE
Fixed bug in the parallel computation of transmissibilities

### DIFF
--- a/src/coreComponents/finiteVolume/TwoPointFluxApproximation.cpp
+++ b/src/coreComponents/finiteVolume/TwoPointFluxApproximation.cpp
@@ -202,6 +202,11 @@ void TwoPointFluxApproximation::computeCellStencil( MeshLevel & mesh ) const
       std::swap( regionIndex[0], regionIndex[1] );
       std::swap( subRegionIndex[0], subRegionIndex[1] );
       std::swap( elementIndex[0], elementIndex[1] );
+      std::swap( stencilWeights[0], stencilWeights[1] );
+      std::swap( stencilStabilizationWeights[0], stencilStabilizationWeights[1] );
+      std::swap( cellToFaceVec[0][0], cellToFaceVec[1][0] );
+      std::swap( cellToFaceVec[0][1], cellToFaceVec[1][1] );
+      std::swap( cellToFaceVec[0][2], cellToFaceVec[1][2] );
     }
 
     stencil.add( 2,


### PR DESCRIPTION
Users reported that the results (pressure, saturation, etc) produced by GEOS can vary quite a bit between a serial run and many-ranks runs. I used the test case posted in #2365 to identify an issue that was causing the issue.

In the computation of transmissibilities, [here](https://github.com/GEOSX/GEOS/blob/f529cfdb680b95eeabef2b0ff1494234d5e9a299/src/coreComponents/finiteVolume/TwoPointFluxApproximation.cpp#L200) we swap the indices of the element region/subregion/indices depending on the global indices, but we don't swap quantities like `stencilWeights` and `cellToFaceVec`, which results in an inconsistency [here](https://github.com/GEOSX/GEOS/blob/f529cfdb680b95eeabef2b0ff1494234d5e9a299/src/coreComponents/finiteVolume/CellElementStencilTPFA.hpp#L234). 

Swapping everything as done in this PR fixes the problem and produces consistent serial and parallel runs.

Resolves #2365 

Requires rebaseline of two integrated tests: `isothermalLeakyWell_smoke_3d_04` and `thermalLeakyWell_smoke_3d_04`

Rebaseline done in https://github.com/GEOSX/integratedTests/pull/313