### PR TITLE
Disabled time frequency for solver events

### DIFF
--- a/inputFiles/solidMechanics/ExtendedDruckerPragerWellbore_smoke.xml
+++ b/inputFiles/solidMechanics/ExtendedDruckerPragerWellbore_smoke.xml
@@ -30,7 +30,7 @@
     maxTime="1.0">
     <PeriodicEvent
       name="solverApplications"
-      timeFrequency="1.0"
+      forceDt="1.0"
       targetExactTimestep="1"
       target="/Solvers/mechanicsSolver"/>
 

--- a/inputFiles/solidMechanics/KirschProblem_smoke.xml
+++ b/inputFiles/solidMechanics/KirschProblem_smoke.xml
@@ -28,7 +28,7 @@
   <Events maxTime="1.0">
     <PeriodicEvent
       name="solverApplications"
-      timeFrequency="1"
+      forceDt="1"
       targetExactTimestep="1"
       target="/Solvers/mechanicsSolver"
     />

--- a/inputFiles/solidMechanics/ModifiedCamClayWellbore_smoke.xml
+++ b/inputFiles/solidMechanics/ModifiedCamClayWellbore_smoke.xml
@@ -27,7 +27,7 @@
     maxTime="1.0">
     <PeriodicEvent
       name="solverApplications"
-      timeFrequency="1.0"
+      forceDt="1.0"
       targetExactTimestep="1"
       target="/Solvers/mechanicsSolver"/>
 

--- a/src/coreComponents/dataRepository/ExecutableGroup.hpp
+++ b/src/coreComponents/dataRepository/ExecutableGroup.hpp
@@ -19,6 +19,7 @@
 #ifndef GEOSX_DATAREPOSITORY_EXECUTABLEGROUP_HPP_
 #define GEOSX_DATAREPOSITORY_EXECUTABLEGROUP_HPP_
 
+#include "codingUtilities/EnumStrings.hpp"
 #include "common/DataTypes.hpp"
 #include "Group.hpp"
 
@@ -96,24 +97,37 @@ public:
     return 1e99;
   }
 
+  /**
+   * @brief Timestepping type.
+   */
+  enum class TimesteppingBehavior : integer
+  {
+    DeterminesTimeStepSize, ///< The group (say, the solver) does the timestepping
+    DoesNotDetermineTimeStepSize ///< The event targetting this group does the timestepping
+  };
 
   /**
    * @brief Set the timestep behavior for a target.
-   * @param[in] behavior if positive, target does time stepping
+   * @param[in] timesteppingBehavior the timestepping behavior
    */
-  void setTimestepBehavior( integer const behavior ) { m_timestepType = behavior; }
+  void setTimesteppingBehavior( TimesteppingBehavior const timesteppingBehavior ) { m_timesteppingBehavior = timesteppingBehavior; }
 
   /**
    * @brief Get the target's time step behavior.
-   * @return @p >0 if target does time stepping, @p <=0 otherwise
+   * @return The time stepping type
    */
-  integer getTimestepBehavior() { return m_timestepType; }
-
+  TimesteppingBehavior getTimesteppingBehavior() { return m_timesteppingBehavior; }
 
 private:
-  integer m_timestepType = 0;
+
+  TimesteppingBehavior m_timesteppingBehavior = TimesteppingBehavior::DoesNotDetermineTimeStepSize;
 };
 
+/** @cond DO_NOT_DOCUMENT */
+ENUM_STRINGS( ExecutableGroup::TimesteppingBehavior,
+              "DeterminesTimeStepSize",
+              "DoesNotDetermineTimeStepSize" );
+/** @endcond */
 
 }
 

--- a/src/coreComponents/events/EventBase.cpp
+++ b/src/coreComponents/events/EventBase.cpp
@@ -338,7 +338,7 @@ void EventBase::getExecutionOrder( array1d< integer > & eventCounters )
   ++eventCounters[0];
   if( m_target != nullptr )
   {
-    if( m_target->getTimestepBehavior() > 0 )
+    if( m_target->getTimesteppingBehavior() == ExecutableGroup::TimesteppingBehavior::DeterminesTimeStepSize )
     {
       ++eventCounters[1];
     }

--- a/src/coreComponents/events/EventBase.hpp
+++ b/src/coreComponents/events/EventBase.hpp
@@ -160,6 +160,11 @@ public:
     return std::numeric_limits< real64 >::max();
   }
 
+  /**
+   * @brief Helper function to validate the consistency of the event input
+   * @note We cannot use postProcessInput here because we can perform the validation only after the m_target pointer is set
+   */
+  virtual void validate() const {};
 
   /**
    * @brief Count the number of events/sub-events

--- a/src/coreComponents/events/EventManager.cpp
+++ b/src/coreComponents/events/EventManager.cpp
@@ -113,6 +113,7 @@ bool EventManager::run( DomainPartition & domain )
   {
     subEvent.getTargetReferences();
     subEvent.getExecutionOrder( eventCounters );
+    subEvent.validate();
   } );
 
   // Set the progress indicators

--- a/src/coreComponents/events/PeriodicEvent.cpp
+++ b/src/coreComponents/events/PeriodicEvent.cpp
@@ -17,6 +17,8 @@
  */
 
 #include "PeriodicEvent.hpp"
+
+#include "common/Format.hpp"
 #include "functions/FunctionManager.hpp"
 
 namespace geosx
@@ -231,6 +233,22 @@ void PeriodicEvent::cleanup( real64 const time_n,
       subEvent.cleanup( time_n, cycleNumber, 0, 0, domain );
     } );
   }
+}
+
+void PeriodicEvent::validate() const
+{
+  GEOSX_THROW_IF( m_timeFrequency > 0 &&
+                  getEventTarget()->getTimesteppingBehavior() == ExecutableGroup::TimesteppingBehavior::DeterminesTimeStepSize,
+                  GEOSX_FMT(
+                    "`{}`: This event targets an object that automatically selects the time step size. Therefore, `{}` cannot be used here. However, forcing a constant time step size can still be achived with `{}`.",
+                    getName(), viewKeyStruct::timeFrequencyString(), EventBase::viewKeyStruct::forceDtString() ),
+                  InputError );
+  GEOSX_THROW_IF( m_cycleFrequency != 1 &&
+                  getEventTarget()->getTimesteppingBehavior() == ExecutableGroup::TimesteppingBehavior::DeterminesTimeStepSize,
+                  GEOSX_FMT(
+                    "`{}`: This event targets an object that automatically selects the time step size. Therefore, `{}` cannot be used here. However, forcing a constant time step size can still be achived with `{}`.",
+                    getName(), viewKeyStruct::cycleFrequencyString(), EventBase::viewKeyStruct::forceDtString() ),
+                  InputError );
 }
 
 REGISTER_CATALOG_ENTRY( EventBase, PeriodicEvent, string const &, Group * const )

--- a/src/coreComponents/events/PeriodicEvent.hpp
+++ b/src/coreComponents/events/PeriodicEvent.hpp
@@ -102,6 +102,10 @@ public:
                         real64 const eventProgress,
                         DomainPartition & domain ) override;
 
+  /**
+   * @copydoc EventBase::validate
+   */
+  virtual void validate() const override;
 
   /// A pointer to an optional function
   dataRepository::Group * m_functionTarget;

--- a/src/coreComponents/physicsSolvers/SolverBase.cpp
+++ b/src/coreComponents/physicsSolvers/SolverBase.cpp
@@ -48,8 +48,8 @@ SolverBase::SolverBase( string const & name,
   // This enables logLevel filtering
   enableLogLevelInput();
 
-  // This sets a flag to indicate that this object increments time
-  this->setTimestepBehavior( 1 );
+  // This sets a flag to indicate that this object is going to select the time step size
+  this->setTimesteppingBehavior( ExecutableGroup::TimesteppingBehavior::DeterminesTimeStepSize );
 
   registerWrapper( viewKeyStruct::cflFactorString(), &m_cflFactor ).
     setApplyDefaultValue( 0.5 ).


### PR DESCRIPTION
I recently came across some input files from users in which `timeFrequency` was used in solver applications `PeriodicEvents`. This is not working properly because the solvers are selected the time step size, which conflicts with the time frequency specified in the XML file, resulting in skipped solver applications:
```
Time: 3000s, dt:4000s, Cycle: 3                                                                                                                                                          
Time: 7000s, dt:94000s, Cycle: 4                                                                                                                                                         
Time: 101000s, dt:4000s, Cycle: 5                                                                                                                                                        
    Attempt:  0, ConfigurationIter:  0, NewtonIter:  0                                                                                                                                   
    ( Rsolid ) = ( 9.01e-15 ) ;     ( Rflow ) = ( 1.11e-03 ) ;     ( Rwell ) = ( 3.19e-07 ) ;     ( R ) = ( 1.11e-03 ) ;                                                                 
    Attempt:  0, ConfigurationIter:  0, NewtonIter:  1  
```

This PR modifies some `Events` files to disable the `timeFrequency` and `cycleFrequency` keywords for solver events.

Requires rebaseline