### PR TITLE
Implemented a check on minimum pore volume

### DIFF
--- a/src/coreComponents/physicsSolvers/CMakeLists.txt
+++ b/src/coreComponents/physicsSolvers/CMakeLists.txt
@@ -33,6 +33,7 @@ set( physicsSolvers_headers
      fluidFlow/ReactiveCompositionalMultiphaseOBLKernels.hpp
      fluidFlow/FlowSolverBase.hpp
      fluidFlow/FlowSolverBaseFields.hpp
+     fluidFlow/FlowSolverBaseKernels.hpp     
      fluidFlow/FluxKernelsHelper.hpp
      fluidFlow/HybridFVMHelperKernels.hpp
      fluidFlow/proppantTransport/ProppantTransport.hpp

--- a/src/coreComponents/physicsSolvers/fluidFlow/CompositionalMultiphaseBase.cpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/CompositionalMultiphaseBase.cpp
@@ -1102,6 +1102,10 @@ void CompositionalMultiphaseBase::initializePostInitialConditionsPreSubGroups()
     } );
 
   } );
+
+  // report to the user if some pore volumes are very small
+  // note: this function is here because: 1) porosity has been initialized and 2) NTG has been applied
+  validatePoreVolumes( domain );
 }
 
 void

--- a/src/coreComponents/physicsSolvers/fluidFlow/FlowSolverBase.hpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/FlowSolverBase.hpp
@@ -122,6 +122,12 @@ protected:
                                           real64 const & dt,
                                           DomainPartition & domain );
 
+  /**
+   * @brief Helper function to compute/report the elements with small pore volumes
+   * @param[in] domain the domain partition
+   */
+  virtual void validatePoreVolumes( DomainPartition const & domain ) const;
+
   virtual void precomputeData( MeshLevel & mesh,
                                arrayView1d< string const > const & regionNames );
 

--- a/src/coreComponents/physicsSolvers/fluidFlow/FlowSolverBaseKernels.hpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/FlowSolverBaseKernels.hpp
@@ -1,0 +1,82 @@
+/*
+ * ------------------------------------------------------------------------------------------------------------
+ * SPDX-License-Identifier: LGPL-2.1-only
+ *
+ * Copyright (c) 2018-2020 Lawrence Livermore National Security LLC
+ * Copyright (c) 2018-2020 The Board of Trustees of the Leland Stanford Junior University
+ * Copyright (c) 2018-2020 TotalEnergies
+ * Copyright (c) 2019-     GEOSX Contributors
+ * All rights reserved
+ *
+ * See top level LICENSE, COPYRIGHT, CONTRIBUTORS, NOTICE, and ACKNOWLEDGEMENTS files for details.
+ * ------------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * @file FlowSolverBaseKernels.hpp
+ */
+
+#ifndef GEOSX_PHYSICSSOLVERS_FLUIDFLOW_FLOWSOLVERBASEKERNELS_HPP
+#define GEOSX_PHYSICSSOLVERS_FLUIDFLOW_FLOWSOLVERBASEKERNELS_HPP
+
+#include "common/DataTypes.hpp"
+#include "common/GEOS_RAJA_Interface.hpp"
+
+namespace geosx
+{
+
+namespace flowSolverBaseKernels
+{
+
+/**
+ * @struct MinimumPoreVolumeKernel
+ * @brief Kernel to compute the min pore volume in a subRegion
+ */
+struct MinimumPoreVolumeKernel
+{
+
+  /// Threshold for the min pore volume (below, a warning is issued)
+  static constexpr real64 poreVolumeThreshold = 1e-4;
+
+  /*
+   * @brief Kernel computing the min pore volume
+   * @param[in] size the number of elements in the subRegion
+   * @param[in] porosity the current element porosity
+   * @param[in] volume the current element volume
+   * @param[out] minPoreVolumeInSubRegion the min pore volume
+   * @param[out] numElemsBelowThresholdInSubRegion the number of elements is below the threshold
+   */
+  static void
+  computeMinimumPoreVolume( localIndex const size,
+                            arrayView2d< real64 const > const & porosity,
+                            arrayView1d< real64 const > const & volume,
+                            real64 & minPoreVolumeInSubRegion,
+                            localIndex & numElemsBelowThresholdInSubRegion )
+  {
+    RAJA::ReduceMin< parallelDeviceReduce, real64 > minPoreVolume( LvArray::NumericLimits< real64 >::max );
+    RAJA::ReduceSum< parallelDeviceReduce, localIndex > numElemsBelowThreshold( 0.0 );
+
+    forAll< parallelDevicePolicy<> >( size, [porosity,
+                                             volume,
+                                             minPoreVolume,
+                                             numElemsBelowThreshold] ( localIndex const ei )
+    {
+      real64 const poreVolume = porosity[ei][0] * volume[ei];
+      if( poreVolume < poreVolumeThreshold )
+      {
+        numElemsBelowThreshold += 1;
+      }
+      minPoreVolume.min( poreVolume );
+    } );
+
+    minPoreVolumeInSubRegion = minPoreVolume.get();
+    numElemsBelowThresholdInSubRegion = numElemsBelowThreshold.get();
+  }
+};
+
+
+} // namespace flowSolverBaseKernels
+
+} // namespace geosx
+
+#endif //GEOSX_PHYSICSSOLVERS_FLUIDFLOW_FLOWSOLVERBASEKERNELS_HPP

--- a/src/coreComponents/physicsSolvers/fluidFlow/SinglePhaseBase.cpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/SinglePhaseBase.cpp
@@ -415,6 +415,10 @@ void SinglePhaseBase::initializePostInitialConditionsPreSubGroups()
       initTemp.setValues< parallelDevicePolicy<> >( temp );
     } );
   } );
+
+  // report to the user if some pore volumes are very small
+  // note: this function is here because: 1) porosity has been initialized and 2) NTG has been applied
+  validatePoreVolumes( domain );
 }
 
 void SinglePhaseBase::computeHydrostaticEquilibrium()
@@ -610,7 +614,7 @@ void SinglePhaseBase::implicitStepSetup( real64 const & GEOSX_UNUSED_PARAM( time
 
       pres_n.setValues< parallelDevicePolicy<> >( pres );
       singlePhaseBaseKernels::StatisticsKernel::
-        saveDeltaPressure< parallelDevicePolicy<> >( subRegion.size(), pres, initPres, deltaPres );
+        saveDeltaPressure( subRegion.size(), pres, initPres, deltaPres );
 
       if( m_isThermal )
       {

--- a/src/coreComponents/physicsSolvers/fluidFlow/SinglePhaseBaseKernels.hpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/SinglePhaseBaseKernels.hpp
@@ -612,7 +612,6 @@ struct SolutionCheckKernel
 
 struct StatisticsKernel
 {
-  template< typename POLICY >
   static void
   saveDeltaPressure( localIndex const size,
                      arrayView1d< real64 const > const & pres,
@@ -625,7 +624,6 @@ struct StatisticsKernel
     } );
   }
 
-  template< typename POLICY >
   static void
   launch( localIndex const size,
           arrayView1d< integer const > const & elemGhostRank,

--- a/src/coreComponents/physicsSolvers/fluidFlow/SinglePhaseStatistics.cpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/SinglePhaseStatistics.cpp
@@ -127,20 +127,20 @@ void SinglePhaseStatistics::computeRegionStatistics( MeshLevel & mesh,
     real64 subRegionTotalPoreVol = 0.0;
 
     singlePhaseBaseKernels::StatisticsKernel::
-      launch< parallelDevicePolicy<> >( subRegion.size(),
-                                        elemGhostRank,
-                                        volume,
-                                        pres,
-                                        deltaPres,
-                                        refPorosity,
-                                        porosity,
-                                        subRegionMinPres,
-                                        subRegionAvgPresNumerator,
-                                        subRegionMaxPres,
-                                        subRegionMinDeltaPres,
-                                        subRegionMaxDeltaPres,
-                                        subRegionTotalUncompactedPoreVol,
-                                        subRegionTotalPoreVol );
+      launch( subRegion.size(),
+              elemGhostRank,
+              volume,
+              pres,
+              deltaPres,
+              refPorosity,
+              porosity,
+              subRegionMinPres,
+              subRegionAvgPresNumerator,
+              subRegionMaxPres,
+              subRegionMinDeltaPres,
+              subRegionMaxDeltaPres,
+              subRegionTotalUncompactedPoreVol,
+              subRegionTotalPoreVol );
 
     ElementRegionBase & region = elemManager.getRegion( subRegion.getParent().getParent().getName() );
     RegionStatistics & regionStatistics = region.getReference< RegionStatistics >( viewKeyStruct::regionStatisticsString() );


### PR DESCRIPTION
This PR implements a check on the cell pore volume in the matrix. The user will have a warning at the beginning of the simulation if the cell pore volume is below a threshold (number of cells with a pore volume below the threshold, minimum pore volume).

Ready for review