### PR TITLE
Fixed uninitialized variables in flux kernels

### DIFF
--- a/src/coreComponents/physicsSolvers/multiphysics/SinglePhasePoromechanicsFluxKernels.cpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/SinglePhasePoromechanicsFluxKernels.cpp
@@ -150,9 +150,9 @@ void EmbeddedSurfaceFluxKernel::
     stackArray2d< real64, MAX_NUM_FLUX_ELEMS * maxStencilSize * 4 > localFluxJacobian( numFluxElems, numDofs );
 
     // compute transmissibility
-    real64 transmissibility[SurfaceElementStencilWrapper::maxNumConnections][2];
-    real64 dTrans_dPres[SurfaceElementStencilWrapper::maxNumConnections][2];
-    real64 dTrans_dDispJump[SurfaceElementStencilWrapper::maxNumConnections][2][3];
+    real64 transmissibility[SurfaceElementStencilWrapper::maxNumConnections][2]{};
+    real64 dTrans_dPres[SurfaceElementStencilWrapper::maxNumConnections][2]{};
+    real64 dTrans_dDispJump[SurfaceElementStencilWrapper::maxNumConnections][2][3]{}; // make sure that this is initialized!
 
     stencilWrapper.computeWeights( iconn,
                                    permeability,
@@ -414,9 +414,9 @@ void FaceElementFluxKernel::
       stackArray2d< real64, maxNumFluxElems * maxStencilSize > dFlux_dAper( numFluxElems, stencilSize );
 
       // compute transmissibility
-      real64 transmissibility[SurfaceElementStencilWrapper::maxNumConnections][2];
-      real64 dTrans_dPres[SurfaceElementStencilWrapper::maxNumConnections][2];
-      real64 dTrans_dDispJump[SurfaceElementStencilWrapper::maxNumConnections][2][3];
+      real64 transmissibility[SurfaceElementStencilWrapper::maxNumConnections][2]{};
+      real64 dTrans_dPres[SurfaceElementStencilWrapper::maxNumConnections][2]{};
+      real64 dTrans_dDispJump[SurfaceElementStencilWrapper::maxNumConnections][2][3]{};
 
       stencilWrapper.computeWeights( iconn,
                                      permeability,


### PR DESCRIPTION
We have some issues with compiler-dependent integrated tests that only work with `clang-10 release` (see for instance: https://github.com/GEOSX/GEOS/issues/2172), and sometimes, do not work at all.

One issue comes from an uninitialized variable in the flux kernel (`dTrans_dDispJump`) declared [here](https://github.com/GEOSX/GEOS/blob/420484d755dfe29fe7639748bcabb8028e4dff98/src/coreComponents/physicsSolvers/multiphysics/SinglePhasePoromechanicsFluxKernels.cpp#L155), only partially initialized [here](https://github.com/GEOSX/GEOS/blob/420484d755dfe29fe7639748bcabb8028e4dff98/src/coreComponents/finiteVolume/SurfaceElementStencil.hpp#L491), and then used [here](https://github.com/GEOSX/GEOS/blob/420484d755dfe29fe7639748bcabb8028e4dff98/src/coreComponents/physicsSolvers/multiphysics/SinglePhasePoromechanicsFluxKernels.cpp#L266).

For me on Quartz, this small fix eliminates the `FAIL_RUN` and `FAIL_CHECK` for gcc-8.3.1 (release and debug) and clang-10 (debug) for the following tests:
- `ExponentialDecayPermeability_edfm_smoke.xml`
- `PoroElastic_efem-edfm_verticalFrac_smoke.xml`
- `SlipPermeability_pEDFM_smoke.xml`
- `WillisRichardsPermeability_efem-edfm_smoke.xml`

and possibly others as well

Resolves #2172 